### PR TITLE
[Issue #3] Implement minimal end-to-end Linear API query

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,11 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: check-commit-msg
+        name: Check commit message
+        entry: scripts/check-commit-msg.py
+        language: python
+        stages: [commit-msg]
+        always_run: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +250,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -818,6 +850,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +901,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "env_logger",
  "linear-sdk",
  "tokio",
 ]
@@ -1052,6 +1109,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1164,35 @@ checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/linear-cli/Cargo.toml
+++ b/linear-cli/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.39", features = ["derive"] }
+env_logger = "0.11.5"
 linear-sdk = { version = "0.1.0", path = "../linear-sdk" }
 tokio = { version = "1.45.1", features = ["full"] }

--- a/linear-cli/src/main.rs
+++ b/linear-cli/src/main.rs
@@ -1,8 +1,35 @@
 // ABOUTME: Main entry point for the Linear CLI application
 // ABOUTME: Provides command-line interface for Linear issue tracking
 
-fn main() {
-    println!("Linear CLI");
+use anyhow::Result;
+use linear_sdk::LinearClient;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+
+    let api_key = match env::var("LINEAR_API_KEY") {
+        Ok(key) => key,
+        Err(_) => {
+            eprintln!("Error: No LINEAR_API_KEY environment variable found");
+            eprintln!();
+            eprintln!("Please set your Linear API key:");
+            eprintln!("export LINEAR_API_KEY=lin_api_xxxxx");
+            eprintln!();
+            eprintln!("Get your API key from: https://linear.app/settings/api");
+            std::process::exit(1);
+        }
+    };
+
+    let client = LinearClient::new(api_key)?;
+    let viewer_data = client.execute_viewer_query().await?;
+
+    println!("Viewer Information:");
+    println!("  Name: {}", viewer_data.viewer.name);
+    println!("  Email: {}", viewer_data.viewer.email);
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/linear-sdk/src/lib.rs
+++ b/linear-sdk/src/lib.rs
@@ -1,7 +1,10 @@
 // ABOUTME: Linear SDK library providing type-safe GraphQL client for Linear API
 // ABOUTME: Includes authentication, queries, mutations, and generated types
 
-use graphql_client::GraphQLQuery;
+use anyhow::Result;
+use graphql_client::{GraphQLQuery, Response};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use std::time::Duration;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -11,8 +14,50 @@ use graphql_client::GraphQLQuery;
 )]
 pub struct Viewer;
 
-pub fn hello() -> &'static str {
-    "Linear SDK"
+pub use viewer::ResponseData as ViewerResponseData;
+
+pub struct LinearClient {
+    client: reqwest::Client,
+    _api_key: String,
+}
+
+impl LinearClient {
+    pub fn new(api_key: String) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&api_key)?);
+        headers.insert(USER_AGENT, HeaderValue::from_static("linear-cli/0.1.0"));
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(30))
+            .build()?;
+
+        Ok(Self {
+            client,
+            _api_key: api_key,
+        })
+    }
+
+    pub async fn execute_viewer_query(&self) -> Result<viewer::ResponseData> {
+        let request_body = Viewer::build_query(viewer::Variables {});
+
+        let response = self
+            .client
+            .post("https://api.linear.app/graphql")
+            .json(&request_body)
+            .send()
+            .await?;
+
+        let response_body: Response<viewer::ResponseData> = response.json().await?;
+
+        if let Some(errors) = response_body.errors {
+            return Err(anyhow::anyhow!("GraphQL errors: {:?}", errors));
+        }
+
+        response_body
+            .data
+            .ok_or_else(|| anyhow::anyhow!("No data in response"))
+    }
 }
 
 #[cfg(test)]
@@ -20,13 +65,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_hello() {
-        assert_eq!(hello(), "Linear SDK");
+    fn test_linear_client_creation() {
+        let client = LinearClient::new("test_api_key".to_string());
+        assert!(client.is_ok());
     }
 
     #[test]
     fn test_viewer_query_builds() {
         // This test verifies that the GraphQL code generation worked
         let _query = Viewer::build_query(viewer::Variables {});
+    }
+
+    #[tokio::test]
+    #[ignore] // Run with: cargo test -- --ignored
+    async fn test_real_api() {
+        let api_key = std::env::var("LINEAR_API_KEY")
+            .expect("LINEAR_API_KEY must be set for integration tests");
+
+        let client = LinearClient::new(api_key).expect("Failed to create client");
+        let result = client.execute_viewer_query().await;
+
+        assert!(result.is_ok(), "Query should succeed with valid API key");
+        let data = result.unwrap();
+        assert!(!data.viewer.id.is_empty(), "Viewer should have an ID");
     }
 }

--- a/scripts/check-commit-msg.py
+++ b/scripts/check-commit-msg.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Check commit messages for prohibited words."""
+
+import re
+import sys
+
+
+def main():
+    """Check commit message for prohibited patterns."""
+    # Get the commit message file path from command line arguments
+    if len(sys.argv) < 2:
+        print("ERROR: No commit message file provided")
+        return 1
+
+    commit_msg_file = sys.argv[1]
+
+    # Read the commit message from the file
+    try:
+        with open(commit_msg_file, 'r') as f:
+            commit_msg = f.read()
+    except IOError as e:
+        print(f"ERROR: Could not read commit message file: {e}")
+        return 1
+
+    # Patterns to check (case-insensitive)
+    prohibited_patterns = [
+        r'\banthropic\b',
+        r'\bclaude\b',
+    ]
+
+    for pattern in prohibited_patterns:
+        if re.search(pattern, commit_msg, re.IGNORECASE):
+            print(f"ERROR: Commit message contains prohibited word matching pattern '{pattern}'")
+            print("Please remove references to 'anthropic' or 'claude' from your commit message.")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Implements a minimal working Linear CLI that successfully queries the Linear API
- Adds LinearClient with authentication and viewer query functionality
- Provides helpful error messaging when API key is missing

## Test plan
- [x] Run `LINEAR_API_KEY=xxx cargo run -p linear-cli` to verify viewer info is displayed
- [x] Run without API key to verify helpful error message
- [x] Run `cargo test --workspace` to verify unit tests pass
- [x] Run `cargo test -- --ignored` with valid API key to verify integration test passes
- [x] Run with `RUST_LOG=debug` to verify HTTP debugging works
- [x] Pre-commit hook prevents commits with prohibited words

Closes #3