### PR TITLE
[Issue #5] Basic Issues Query

### DIFF
--- a/linear-cli/src/main.rs
+++ b/linear-cli/src/main.rs
@@ -2,8 +2,27 @@
 // ABOUTME: Provides command-line interface for Linear issue tracking
 
 use anyhow::Result;
+use clap::{Parser, Subcommand};
 use linear_sdk::LinearClient;
 use std::env;
+
+#[derive(Parser)]
+#[command(name = "linear")]
+#[command(about = "A CLI for Linear", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List issues
+    Issues {
+        /// Maximum number of issues to fetch
+        #[arg(short, long, default_value = "20")]
+        limit: i32,
+    },
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -22,21 +41,82 @@ async fn main() -> Result<()> {
         }
     };
 
+    let cli = Cli::parse();
     let client = LinearClient::new(api_key)?;
-    let viewer_data = client.execute_viewer_query().await?;
 
-    println!("Viewer Information:");
-    println!("  Name: {}", viewer_data.viewer.name);
-    println!("  Email: {}", viewer_data.viewer.email);
+    match cli.command {
+        Commands::Issues { limit } => {
+            let issues = client.list_issues(limit).await?;
+
+            if issues.is_empty() {
+                println!("No issues found.");
+            } else {
+                for issue in issues {
+                    let assignee = issue.assignee.unwrap_or_else(|| "Unassigned".to_string());
+                    println!(
+                        "{}: {} ({}) - {}",
+                        issue.identifier, issue.title, issue.status, assignee
+                    );
+                }
+            }
+        }
+    }
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
     #[test]
-    fn test_placeholder() {
-        // Placeholder test until we have actual functionality
-        assert_eq!(1 + 1, 2);
+    fn test_cli_structure() {
+        let cli = Cli::command();
+
+        // Verify basic structure
+        assert_eq!(cli.get_name(), "linear");
+
+        // Check that we have the issues subcommand
+        let issues_cmd = cli
+            .find_subcommand("issues")
+            .expect("issues command should exist");
+        assert_eq!(issues_cmd.get_name(), "issues");
+
+        // Check the limit argument
+        let limit_arg = issues_cmd
+            .get_arguments()
+            .find(|arg| arg.get_id() == "limit")
+            .expect("limit argument should exist");
+        assert!(!limit_arg.is_required_set());
+    }
+
+    #[test]
+    fn test_parse_issues_command() {
+        use clap::Parser;
+
+        // Test default limit
+        let cli = Cli::try_parse_from(["linear", "issues"]).unwrap();
+        match cli.command {
+            Commands::Issues { limit } => {
+                assert_eq!(limit, 20);
+            }
+        }
+
+        // Test custom limit
+        let cli = Cli::try_parse_from(["linear", "issues", "--limit", "5"]).unwrap();
+        match cli.command {
+            Commands::Issues { limit } => {
+                assert_eq!(limit, 5);
+            }
+        }
+
+        // Test short form
+        let cli = Cli::try_parse_from(["linear", "issues", "-l", "10"]).unwrap();
+        match cli.command {
+            Commands::Issues { limit } => {
+                assert_eq!(limit, 10);
+            }
+        }
     }
 }

--- a/linear-sdk/graphql/queries/issues.graphql
+++ b/linear-sdk/graphql/queries/issues.graphql
@@ -1,0 +1,15 @@
+query ListIssues($first: Int!) {
+  issues(first: $first) {
+    nodes {
+      id
+      identifier
+      title
+      state {
+        name
+      }
+      assignee {
+        name
+      }
+    }
+  }
+}

--- a/linear-sdk/src/test_helpers.rs
+++ b/linear-sdk/src/test_helpers.rs
@@ -34,15 +34,45 @@ pub fn mock_issues_response() -> serde_json::Value {
                         "id": "issue-1",
                         "title": "Test Issue 1",
                         "identifier": "TEST-1",
-                        "description": "Test description 1"
+                        "state": {
+                            "name": "Todo"
+                        },
+                        "assignee": {
+                            "name": "Alice"
+                        }
                     },
                     {
                         "id": "issue-2",
                         "title": "Test Issue 2",
                         "identifier": "TEST-2",
-                        "description": "Test description 2"
+                        "state": {
+                            "name": "In Progress"
+                        },
+                        "assignee": {
+                            "name": "Bob"
+                        }
+                    },
+                    {
+                        "id": "issue-3",
+                        "title": "Test Issue 3",
+                        "identifier": "TEST-3",
+                        "state": {
+                            "name": "Done"
+                        },
+                        "assignee": null
                     }
                 ]
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+pub fn mock_empty_issues_response() -> serde_json::Value {
+    json!({
+        "data": {
+            "issues": {
+                "nodes": []
             }
         }
     })


### PR DESCRIPTION
## Summary
- Implements the first real feature: listing Linear issues via CLI
- Adds GraphQL query support for fetching issues
- Establishes patterns for future commands

## Changes Made

### SDK Enhancements
- Added `issues.graphql` query file for fetching issues with state and assignee
- Created simplified `Issue` struct for domain modeling
- Implemented `list_issues(&self, limit: i32)` method on LinearClient
- Added comprehensive test coverage including mocked responses

### CLI Implementation
- Added clap-based command structure with subcommands
- Implemented `linear issues` command with optional `--limit` flag
- Format output as: "ISSUE-ID: Title (Status) - Assignee"
- Gracefully handle unassigned issues

## Test Plan
- [x] Unit tests for SDK list_issues method pass
- [x] Integration tests with mocked API responses pass
- [x] CLI parsing tests pass
- [x] Empty results case handled correctly
- [x] All tests pass: `cargo test --workspace`
- [x] No clippy warnings: `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Code formatted: `cargo fmt --all`
- [x] Pre-commit hooks pass

## Usage Example
```bash
# List up to 20 issues (default)
linear issues

# List up to 5 issues
linear issues --limit 5
# or
linear issues -l 5
```

Fixes #5