### PR TITLE
[Issue #46] Automatically disable colors and UI treatments when output is piped

### DIFF
--- a/linear-cli/src/output.rs
+++ b/linear-cli/src/output.rs
@@ -38,11 +38,23 @@ pub trait OutputFormat {
 
 pub struct TableFormatter {
     use_color: bool,
+    is_interactive: bool,
 }
 
 impl TableFormatter {
+    #[cfg(test)]
     pub fn new(use_color: bool) -> Self {
-        Self { use_color }
+        Self {
+            use_color,
+            is_interactive: use_color,
+        }
+    }
+
+    pub fn new_with_interactive(use_color: bool, is_interactive: bool) -> Self {
+        Self {
+            use_color,
+            is_interactive,
+        }
     }
 
     fn truncate_title(title: &str, max_len: usize) -> String {
@@ -534,7 +546,12 @@ impl OutputFormat for TableFormatter {
             .collect();
 
         let mut table = Table::new(rows);
-        table.with(Style::psql());
+        if self.is_interactive {
+            table.with(Style::psql());
+        } else {
+            // Use minimal style for piped output
+            table.with(Style::blank());
+        }
         Ok(table.to_string())
     }
 

--- a/linear-cli/src/snapshots/linear_cli__output__tests__snapshot_empty_results.snap
+++ b/linear-cli/src/snapshots/linear_cli__output__tests__snapshot_empty_results.snap
@@ -2,5 +2,4 @@
 source: linear-cli/src/output.rs
 expression: result
 ---
- Issue | Title | Status | Assignee 
--------+-------+--------+----------
+ Issue   Title   Status   Assignee

--- a/linear-cli/src/snapshots/linear_cli__output__tests__snapshot_long_titles.snap
+++ b/linear-cli/src/snapshots/linear_cli__output__tests__snapshot_long_titles.snap
@@ -2,7 +2,6 @@
 source: linear-cli/src/output.rs
 expression: result
 ---
- Issue   | Title                                    | Status | Assignee                                         
----------+------------------------------------------+--------+--------------------------------------------------
- ENG-200 | This is a very long title that defini... | Todo   | Very Long Assignee Name That Also Gets Displayed 
- ENG-201 | Short title                              | Done   | Unassigned
+ Issue     Title                                      Status   Assignee                                         
+ ENG-200   This is a very long title that defini...   Todo     Very Long Assignee Name That Also Gets Displayed 
+ ENG-201   Short title                                Done     Unassigned

--- a/linear-cli/src/snapshots/linear_cli__output__tests__snapshot_noncolored_output.snap
+++ b/linear-cli/src/snapshots/linear_cli__output__tests__snapshot_noncolored_output.snap
@@ -2,8 +2,7 @@
 source: linear-cli/src/output.rs
 expression: result
 ---
- Issue   | Title                       | Status      | Assignee    
----------+-----------------------------+-------------+-------------
- ENG-100 | Fix authentication bug      | Todo        | Alice Smith 
- ENG-101 | Implement user profile page | In Progress | Unassigned  
- ENG-102 | Update documentation        | Done        | Bob Johnson
+ Issue     Title                         Status        Assignee    
+ ENG-100   Fix authentication bug        Todo          Alice Smith 
+ ENG-101   Implement user profile page   In Progress   Unassigned  
+ ENG-102   Update documentation          Done          Bob Johnson


### PR DESCRIPTION
## Summary
- Implements automatic TTY detection to provide cleaner output for command pipelines
- Adds `--force-color` flag to override automatic detection when needed
- Updates all UI elements (spinners, tables, status messages) to respect TTY state

## Changes

### TTY Detection
- Added `IsTerminal` trait to detect when stdout is connected to a terminal
- Created `determine_use_color()` function that checks:
  - TTY status
  - `--no-color` and `--force-color` flags
  - `NO_COLOR` environment variable
  - `TERM=dumb` environment variable

### UI Adaptations
- **Spinners**: Only show progress spinners in interactive terminals
- **Tables**: Use minimal style (no borders) when output is piped
- **Status Messages**: Suppress "No issues found" and connection status when piped
- **Markdown**: Preserve rich formatting only in interactive terminals

### Additional Improvements
- Added input validation to ensure issue limit is at least 1
- Fixed tests to handle new table formatting

## Test Plan
- [x] Run `linear issues | cat` - should show no colors or borders
- [x] Run `linear issues > file.txt` - file should contain plain text
- [x] Run `linear issues` - should show colors and formatting
- [x] Run `linear --force-color issues | cat` - should show colors
- [x] Run `NO_COLOR=1 linear issues` - should show no colors
- [x] Run `linear issues --limit 0` - should show validation error
- [x] All unit tests pass
- [x] Pre-commit hooks pass

Fixes #46