### PR TITLE
Enhance linear create command with team resolution and caching

### DIFF
--- a/linear-sdk/graphql/queries/teams.graphql
+++ b/linear-sdk/graphql/queries/teams.graphql
@@ -1,0 +1,10 @@
+query ListTeams($first: Int!) {
+  teams(first: $first) {
+    nodes {
+      id
+      key
+      name
+      description
+    }
+  }
+}

--- a/linear-sdk/src/test_helpers.rs
+++ b/linear-sdk/src/test_helpers.rs
@@ -260,3 +260,33 @@ pub fn mock_create_issue_failure_response() -> serde_json::Value {
         }
     })
 }
+
+#[cfg(test)]
+pub fn mock_teams_response() -> serde_json::Value {
+    json!({
+        "data": {
+            "teams": {
+                "nodes": [
+                    {
+                        "id": "team-eng-uuid",
+                        "key": "ENG",
+                        "name": "Engineering",
+                        "description": "Engineering team responsible for product development"
+                    },
+                    {
+                        "id": "team-design-uuid",
+                        "key": "DESIGN",
+                        "name": "Design",
+                        "description": "Product design and user experience"
+                    },
+                    {
+                        "id": "team-qa-uuid",
+                        "key": "QA",
+                        "name": "Quality Assurance",
+                        "description": null
+                    }
+                ]
+            }
+        }
+    })
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of issue #78 to enhance the `linear create` command with user-friendly team key resolution and performance optimizations.

### Key Features Added

- **Team Key Resolution**: Accept user-friendly team keys (e.g., `ENG`, `DESIGN`) in addition to UUIDs
- **Intelligent Fallback**: Automatically detect UUIDs vs team keys for backward compatibility
- **In-Memory Caching**: Cache team data to improve performance and reduce API calls
- **Enhanced Error Messages**: Provide helpful feedback with available teams when lookup fails
- **Case-Insensitive Matching**: Support flexible team key input (e.g., `eng`, `ENG`, `Eng`)

### Examples

```bash
# Before: Required team UUID
linear create --title "Fix bug" --team "550e8400-e29b-41d4-a716-446655440000"

# After: Accept friendly team keys
linear create --title "Fix bug" --team "ENG"
linear create --title "Design task" --team "design"  # case-insensitive

# Still works with UUIDs for backward compatibility
linear create --title "Fix bug" --team "550e8400-e29b-41d4-a716-446655440000"
```

### Error Messages

When an invalid team is provided, users now get helpful feedback:
```
Team 'INVALID' not found. Available teams: ENG, DESIGN, QA
```

### Performance

- Teams are cached in memory during the session
- Subsequent team resolutions use cached data
- Debug logging shows cache hits/misses when verbose mode is enabled

### Testing

- **4 new tests** for team listing functionality
- **3 new tests** for team key resolution (success, case-insensitive, not found)
- **1 new test** for caching behavior
- **1 new test** for UUID detection logic
- All existing tests continue to pass

## Technical Implementation

- Added `ListTeams` GraphQL query with comprehensive team data
- Implemented `Team` struct with id, key, name, and description fields
- Added `list_teams()` and `resolve_team_key_to_id()` methods to LinearClient
- Thread-safe caching using `RwLock<Option<Vec<Team>>>`
- Updated CLI argument processing to intelligently handle team keys vs UUIDs

## Test plan

- [x] Team key resolution works for all supported teams
- [x] Case-insensitive matching functions correctly
- [x] Helpful error messages displayed for invalid teams
- [x] Caching reduces API calls for repeated operations
- [x] UUID input continues to work for backward compatibility
- [x] All existing create command functionality preserved
- [x] Comprehensive test coverage for new features

## Related Issues

- Addresses Phase 1 requirements from #78
- Builds upon the foundation from #77 (original create command)
- Sets the stage for Phase 2 (interactive prompts) and Phase 3 (enhanced UX)

---

This PR significantly improves the user experience of the `linear create` command while maintaining full backward compatibility and adding robust error handling.